### PR TITLE
Update mgmt_ipc.c

### DIFF
--- a/usr/mgmt_ipc.c
+++ b/usr/mgmt_ipc.c
@@ -463,7 +463,6 @@ mgmt_ipc_write_rsp(queue_task_t *qtask, int err)
 	qtask->rsp.err = err;
 	if (write(qtask->mgmt_ipc_fd, &qtask->rsp, sizeof(qtask->rsp)) < 0)
 		log_error("IPC qtask write failed: %s", strerror(errno));
-	close(qtask->mgmt_ipc_fd);
 	mgmt_ipc_destroy_queue_task(qtask);
 }
 


### PR DESCRIPTION
Ran into a problem where iscsiadm was closing an already closed fd (returning EBADF).
Seems like the close() in line 466 is redundant as it is done in mgmt_ipc_destroy_queue_task().
Could also assign qtask->mgmt_ipc_fd to NULL, but it seems better to do it this way.